### PR TITLE
build: add dotenv-java dependency for environment variable management

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -81,6 +81,13 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
         </dependency>
+
+        <!-- Dotenv for environment variables -->
+        <dependency>
+            <groupId>io.github.cdimascio</groupId>
+            <artifactId>dotenv-java</artifactId>
+            <version>3.0.0</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/api/src/main/java/com/books/api/BooksAuthorsApiApplication.java
+++ b/api/src/main/java/com/books/api/BooksAuthorsApiApplication.java
@@ -5,11 +5,13 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.domain.EntityScan;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import io.github.cdimascio.dotenv.Dotenv;
 
 /**
  * Main application class for the Books and Authors API.
  * Configures component scanning, entity scanning, and repository scanning
  * across all modules of the application.
+ * Loads environment variables from .env file before starting the application.
  *
  * @author books
  */
@@ -21,10 +23,12 @@ public class BooksAuthorsApiApplication {
 
     /**
      * Main method that starts the Spring Boot application.
+     * Loads environment variables from .env file before starting.
      *
      * @param args command line arguments
      */
     public static void main(String[] args) {
+        Dotenv.configure().load(); // Cargar variables de entorno desde .env
         SpringApplication.run(BooksAuthorsApiApplication.class, args);
     }
 }


### PR DESCRIPTION
Add the dotenv-java dependency to the pom.xml file to enable loading environment variables from a .env file. This change also includes updating the main application class to load these variables before starting the Spring Boot application, improving configuration management and security.