### PR TITLE
feat(security): add rate limiting functionality and related tests

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -137,6 +137,10 @@
                                     <element>CLASS</element>
                                     <includes>
                                         <include>com.books.api.controller.*Controller</include>
+                                        <include>com.books.api.security.*Filter</include>
+                                        <include>com.books.api.security.*Provider</include>
+                                        <include>com.books.api.service.*Service</include>
+                                        <include>com.books.api.config.*Config</include>
                                     </includes>
                                     <limits>
                                         <limit>

--- a/api/src/main/java/com/books/api/config/RateLimitingConfig.java
+++ b/api/src/main/java/com/books/api/config/RateLimitingConfig.java
@@ -1,0 +1,94 @@
+package com.books.api.config;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Configuration properties for rate limiting functionality.
+ * Reads values from application.yml under the 'rate-limiting' prefix.
+ *
+ * @author books
+ */
+@Configuration
+@ConfigurationProperties(prefix = "rate-limiting")
+@Data
+public class RateLimitingConfig {
+
+    /**
+     * Flag to enable/disable rate limiting globally
+     */
+    private boolean enabled = true;
+
+    /**
+     * Default rate limit settings applied to all endpoints
+     * if not specifically configured
+     */
+    private RateLimitSettings defaultSettings = new RateLimitSettings();
+
+    /**
+     * List of endpoint-specific rate limit settings
+     */
+    private List<EndpointLimit> endpoints = new ArrayList<>();
+
+    /**
+     * Strategy to use for rate limiting (IP_ADDRESS, USER, TOKEN)
+     */
+    private String strategy = "IP_ADDRESS";
+
+    /**
+     * Whether to include rate limit headers in responses
+     */
+    private boolean responseHeaders = true;
+
+    /**
+     * Settings for a specific endpoint rate limit
+     */
+    @Data
+    public static class EndpointLimit {
+        /**
+         * URL pattern to match for this rate limit
+         */
+        private String pattern;
+
+        /**
+         * Maximum number of requests allowed in the refresh period
+         */
+        private int limit = 100;
+
+        /**
+         * Time period after which the limit resets
+         */
+        private int refreshPeriod = 60;
+
+        /**
+         * Time unit for the refresh period (SECONDS, MINUTES, etc.)
+         */
+        private TimeUnit timeUnit = TimeUnit.SECONDS;
+    }
+
+    /**
+     * Default rate limit settings
+     */
+    @Data
+    public static class RateLimitSettings {
+        /**
+         * Maximum number of requests allowed in the refresh period
+         */
+        private int limit = 100;
+
+        /**
+         * Time period after which the limit resets
+         */
+        private int refreshPeriod = 60;
+
+        /**
+         * Time unit for the refresh period (SECONDS, MINUTES, etc.)
+         */
+        private TimeUnit timeUnit = TimeUnit.SECONDS;
+    }
+}

--- a/api/src/main/java/com/books/api/security/RateLimitingFilter.java
+++ b/api/src/main/java/com/books/api/security/RateLimitingFilter.java
@@ -1,0 +1,111 @@
+package com.books.api.security;
+
+import com.books.api.config.RateLimitingConfig;
+import com.books.api.config.RateLimitingConfig.EndpointLimit;
+import com.books.api.service.RateLimitingService;
+import com.books.api.service.RateLimitingService.RateLimitInfo;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.UrlPathHelper;
+
+import java.io.IOException;
+
+/**
+ * Filter that implements rate limiting for API endpoints.
+ * Limits requests based on configured thresholds and strategies.
+ * Uses RateLimitingService to manage rate limit logic.
+ *
+ * @author books
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RateLimitingFilter extends OncePerRequestFilter {
+
+    private final RateLimitingConfig rateLimitingConfig;
+    private final RateLimitingService rateLimitingService;
+    private final UrlPathHelper urlPathHelper = new UrlPathHelper();
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        // Skip rate limiting if disabled
+        if (!rateLimitingConfig.isEnabled()) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        // Get the request path
+        String path = urlPathHelper.getPathWithinApplication(request);
+
+        // Find matching endpoint limit configuration
+        EndpointLimit endpointLimit = rateLimitingService.findEndpointLimit(path);
+
+        // Get the key for rate limiting based on strategy
+        String key = getRateLimitKey(request, path);
+
+        // Check if request is allowed
+        boolean allowed = rateLimitingService.isRequestAllowed(key, endpointLimit);
+
+        // Add rate limit headers if configured
+        if (rateLimitingConfig.isResponseHeaders()) {
+            addRateLimitHeaders(response, key, endpointLimit);
+        }
+
+        if (allowed) {
+            filterChain.doFilter(request, response);
+        } else {
+            log.warn("Rate limit exceeded for key: {}, path: {}", key, path);
+            response.setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+            response.getWriter().write("Rate limit exceeded. Please try again later.");
+        }
+    }
+
+    /**
+     * Get the key for rate limiting based on the configured strategy
+     *
+     * @param request The HTTP request
+     * @param path    The request path
+     * @return The rate limiting key
+     */
+    private String getRateLimitKey(HttpServletRequest request, String path) {
+        String strategy = rateLimitingConfig.getStrategy();
+
+        return switch (strategy) {
+            case "IP_ADDRESS" -> request.getRemoteAddr() + ":" + path;
+            case "USER" -> {
+                // Assuming user information is available in the security context
+                // This would need to be adapted based on your authentication setup
+                yield "user:" + path;
+            }
+            case "TOKEN" -> {
+                String token = request.getHeader("Authorization");
+                yield (token != null ? token : "anonymous") + ":" + path;
+            }
+            default -> request.getRemoteAddr() + ":" + path;
+        };
+    }
+
+    /**
+     * Add rate limit headers to the response
+     *
+     * @param response      The HTTP response
+     * @param key           The rate limiting key
+     * @param endpointLimit The endpoint limit configuration
+     */
+    private void addRateLimitHeaders(HttpServletResponse response, String key, EndpointLimit endpointLimit) {
+        RateLimitInfo info = rateLimitingService.getRateLimitInfo(key, endpointLimit);
+
+        response.addHeader("X-RateLimit-Limit", String.valueOf(info.limit()));
+        response.addHeader("X-RateLimit-Remaining", String.valueOf(info.remaining()));
+        response.addHeader("X-RateLimit-Reset", String.valueOf(info.resetTimeMillis()));
+    }
+}

--- a/api/src/main/java/com/books/api/service/RateLimitingService.java
+++ b/api/src/main/java/com/books/api/service/RateLimitingService.java
@@ -1,0 +1,131 @@
+package com.books.api.service;
+
+import com.books.api.config.RateLimitingConfig;
+import com.books.api.config.RateLimitingConfig.EndpointLimit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * Service that manages rate limiting functionality.
+ * Provides methods to check if requests are allowed based on configured limits.
+ *
+ * @author books
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class RateLimitingService {
+
+    private final RateLimitingConfig rateLimitingConfig;
+
+    // Cache to store request counts per key (IP address, user, or token)
+    private final Map<String, RequestCounter> requestCounters = new ConcurrentHashMap<>();
+
+    /**
+     * Checks if a request is allowed based on rate limits for the given key and
+     * endpoint
+     *
+     * @param key           The rate limiting key (IP, user, token + path)
+     * @param endpointLimit The endpoint limit configuration
+     * @return true if request is allowed, false if rate limit exceeded
+     */
+    public boolean isRequestAllowed(String key, EndpointLimit endpointLimit) {
+        if (!rateLimitingConfig.isEnabled()) {
+            return true;
+        }
+
+        RequestCounter counter = requestCounters.computeIfAbsent(key, k -> new RequestCounter());
+        return counter.incrementAndCheckLimit(endpointLimit.getLimit(),
+                endpointLimit.getRefreshPeriod(),
+                endpointLimit.getTimeUnit());
+    }
+
+    /**
+     * Find the appropriate endpoint limit configuration for the given path
+     *
+     * @param path The request path
+     * @return The matching endpoint limit or default settings
+     */
+    public EndpointLimit findEndpointLimit(String path) {
+        return rateLimitingConfig.getEndpoints().stream()
+                .filter(endpoint -> path.matches(endpoint.getPattern()))
+                .findFirst()
+                .orElse(new EndpointLimit() {
+                    {
+                        setLimit(rateLimitingConfig.getDefaultSettings().getLimit());
+                        setRefreshPeriod(rateLimitingConfig.getDefaultSettings().getRefreshPeriod());
+                        setTimeUnit(rateLimitingConfig.getDefaultSettings().getTimeUnit());
+                    }
+                });
+    }
+
+    /**
+     * Get rate limit information for a specific key
+     *
+     * @param key           The rate limiting key
+     * @param endpointLimit The endpoint limit configuration
+     * @return RateLimitInfo containing current limit, remaining requests and reset
+     *         time
+     */
+    public RateLimitInfo getRateLimitInfo(String key, EndpointLimit endpointLimit) {
+        RequestCounter counter = requestCounters.get(key);
+        if (counter == null) {
+            return new RateLimitInfo(endpointLimit.getLimit(), endpointLimit.getLimit(), System.currentTimeMillis());
+        }
+
+        return new RateLimitInfo(
+                endpointLimit.getLimit(),
+                Math.max(0, endpointLimit.getLimit() - counter.getCount()),
+                counter.getResetTimeMillis());
+    }
+
+    /**
+     * Data class to hold rate limit information
+     */
+    public record RateLimitInfo(int limit, int remaining, long resetTimeMillis) {
+    }
+
+    /**
+     * Helper class to track request counts and reset times
+     */
+    private static class RequestCounter {
+        private final AtomicInteger count = new AtomicInteger(0);
+        private long resetTimeMillis = System.currentTimeMillis();
+
+        /**
+         * Increment the counter and check if the limit has been exceeded
+         */
+        public synchronized boolean incrementAndCheckLimit(int limit, int refreshPeriod, TimeUnit timeUnit) {
+            long currentTimeMillis = System.currentTimeMillis();
+
+            // Reset counter if refresh period has elapsed
+            if (currentTimeMillis > resetTimeMillis) {
+                count.set(0);
+                resetTimeMillis = currentTimeMillis + timeUnit.toMillis(refreshPeriod);
+            }
+
+            // Increment counter and check against limit
+            return count.incrementAndGet() <= limit;
+        }
+
+        /**
+         * Get the current count
+         */
+        public int getCount() {
+            return count.get();
+        }
+
+        /**
+         * Get the reset time in milliseconds
+         */
+        public long getResetTimeMillis() {
+            return resetTimeMillis;
+        }
+    }
+}

--- a/api/src/main/resources/.env.example
+++ b/api/src/main/resources/.env.example
@@ -4,7 +4,7 @@ DATABASE_USERNAME=Username
 DATABASE_PASSWORD=Password
 
 # JWT Security Configuration
-JWT_SECRET_KEY=mySecretKey
+JWT_SECRET_KEY=mySecretKeyWithAtLeast256BitsForHS512SignatureAlgorithm
 JWT_EXPIRATION=86400000
 
 # Server Configuration

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -49,6 +49,33 @@ security:
   secret-key: ${JWT_SECRET_KEY}
   expiration: ${JWT_EXPIRATION}
 
+# Rate Limiting configuration
+rate-limiting:
+  enabled: true
+  # Default rate limit for all endpoints
+  default:
+    limit: 100
+    refresh-period: 60
+    time-unit: SECONDS
+  # Specific endpoint rate limits
+  endpoints:
+    - pattern: /api/books
+      limit: 50
+      refresh-period: 60
+      time-unit: SECONDS
+    - pattern: /api/authors
+      limit: 50
+      refresh-period: 60
+      time-unit: SECONDS
+    - pattern: /api/authors/generate-token
+      limit: 10
+      refresh-period: 60
+      time-unit: SECONDS
+  # Strategy: IP_ADDRESS, USER, TOKEN
+  strategy: IP_ADDRESS
+  # Response headers
+  response-headers: true
+
 # Logging configuration
 logging:
   level:

--- a/api/src/test/java/com/books/api/config/ApiConfigTest.java
+++ b/api/src/test/java/com/books/api/config/ApiConfigTest.java
@@ -1,0 +1,38 @@
+package com.books.api.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.env.MockEnvironment;
+import org.springframework.test.util.ReflectionTestUtils;
+
+/**
+ * Unit test for ApiConfig class.
+ * Tests the configuration properties without loading the full Spring context.
+ */
+public class ApiConfigTest {
+
+    private ApiConfig apiConfig;
+    private MockEnvironment environment;
+
+    @BeforeEach
+    public void setUp() {
+        // Create a new instance of ApiConfig
+        apiConfig = new ApiConfig();
+
+        // Create a mock environment with our test properties
+        environment = new MockEnvironment();
+        environment.setProperty("CONTEXT_PATH", "/api");
+
+        // Inject the environment into the apiConfig using reflection
+        ReflectionTestUtils.setField(apiConfig, "contextPath", "/api");
+    }
+
+    @Test
+    public void testContextPath() {
+        // Test that the context path is correctly retrieved
+        String expectedContextPath = "/api";
+        assertEquals(expectedContextPath, apiConfig.getContextPath());
+    }
+}

--- a/api/src/test/java/com/books/api/config/OpenApiConfigTest.java
+++ b/api/src/test/java/com/books/api/config/OpenApiConfigTest.java
@@ -1,0 +1,24 @@
+package com.books.api.config;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import io.swagger.v3.oas.models.OpenAPI;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { OpenApiConfig.class })
+public class OpenApiConfigTest {
+
+    @Autowired
+    private OpenAPI openAPI;
+
+    @Test
+    public void testOpenAPIBean() {
+        assertNotNull(openAPI);
+    }
+}

--- a/api/src/test/java/com/books/api/config/RateLimitingConfigTest.java
+++ b/api/src/test/java/com/books/api/config/RateLimitingConfigTest.java
@@ -1,0 +1,22 @@
+package com.books.api.config;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { RateLimitingConfig.class })
+public class RateLimitingConfigTest {
+
+    @Autowired
+    private RateLimitingConfig rateLimitingConfig;
+
+    @Test
+    public void testRateLimitingEnabled() {
+        assertTrue(rateLimitingConfig.isEnabled());
+    }
+}

--- a/api/src/test/java/com/books/api/config/SecurityConfigTest.java
+++ b/api/src/test/java/com/books/api/config/SecurityConfigTest.java
@@ -1,0 +1,66 @@
+package com.books.api.config;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AuthorizeHttpRequestsConfigurer.AuthorizationManagerRequestMatcherRegistry;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import com.books.api.security.JwtTokenFilter;
+import com.books.api.security.RateLimitingFilter;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = { SecurityConfig.class, SecurityConfigTest.TestConfig.class })
+public class SecurityConfigTest {
+
+    @Mock
+    private HttpSecurity httpSecurity;
+
+    @SuppressWarnings("rawtypes")
+    @Mock
+    private AuthorizationManagerRequestMatcherRegistry authorizeRequestsRegistry;
+
+    @Autowired
+    private SecurityConfig securityConfig;
+
+    @TestConfiguration
+    static class TestConfig {
+        @Bean
+        public RateLimitingFilter rateLimitingFilter() {
+            return mock(RateLimitingFilter.class);
+        }
+
+        @Bean
+        public JwtTokenFilter jwtTokenFilter() {
+            return mock(JwtTokenFilter.class);
+        }
+    }
+
+    @Test
+    @DisplayName("You should configure the security filter chain correctly.")
+    void testSecurityFilterChain() throws Exception {
+        // Configure mocks to return the httpSecurity object
+        when(httpSecurity.csrf(any())).thenReturn(httpSecurity);
+        when(httpSecurity.authorizeHttpRequests(any())).thenReturn(httpSecurity);
+        when(httpSecurity.sessionManagement(any())).thenReturn(httpSecurity);
+        when(httpSecurity.addFilterBefore(any(), any())).thenReturn(httpSecurity);
+
+        // Execute the method under test
+        SecurityFilterChain filterChain = securityConfig.securityFilterChain(httpSecurity);
+
+        // Check results
+        assertNotNull(filterChain);
+    }
+}

--- a/api/src/test/java/com/books/api/controller/BookControllerTest.java
+++ b/api/src/test/java/com/books/api/controller/BookControllerTest.java
@@ -48,7 +48,6 @@ public class BookControllerTest {
     private Book book1;
     private Book book2;
     private BookDTO bookDTO1;
-    private BookDTO bookDTO2;
     private CreateBookDTO createBook1;
 
     /**
@@ -80,14 +79,6 @@ public class BookControllerTest {
 
         Set<Long> authorIds2 = new HashSet<>();
         authorIds2.add(2L);
-
-        bookDTO2 = BookDTO.builder()
-                .bookId(2L)
-                .title("El Aleph")
-                .isbn("9788437604848")
-                .publicationDate(LocalDate.of(1949, 6, 15))
-                .authorIds(authorIds2)
-                .build();
 
         // Create test data for Book
         book1 = new Book();

--- a/api/src/test/java/com/books/api/security/JwtTokenFilterTest.java
+++ b/api/src/test/java/com/books/api/security/JwtTokenFilterTest.java
@@ -1,0 +1,176 @@
+package com.books.api.security;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Unit tests for {@link JwtTokenFilter}.
+ * Verifies the filter behavior with different types of JWT tokens.
+ *
+ * @author books
+ */
+@ExtendWith(MockitoExtension.class)
+public class JwtTokenFilterTest {
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain filterChain;
+
+    @Mock
+    private PrintWriter printWriter;
+
+    private JwtTokenFilter jwtTokenFilter;
+    private final String secretKey = "testSecretKeyWithAtLeast256BitsForHS512SignatureAlgorithm";
+
+    @BeforeEach
+    void setUp() throws IOException {
+        lenient().when(response.getWriter()).thenReturn(printWriter);
+
+        jwtTokenFilter = new JwtTokenFilter(secretKey);
+    }
+
+    @Test
+    @DisplayName("Should continue filter chain when there is no authorization token")
+    void shouldContinueFilterChainWhenNoAuthorizationHeader() throws ServletException, IOException {
+        // Given
+        when(request.getHeader("Authorization")).thenReturn(null);
+
+        // When
+        jwtTokenFilter.doFilterInternal(request, response, filterChain);
+
+        // Then
+        verify(filterChain).doFilter(request, response);
+        verifyNoMoreInteractions(response);
+    }
+
+    @Test
+    @DisplayName("Should continue filter chain when header does not start with 'Bearer '")
+    void shouldContinueFilterChainWhenHeaderDoesNotStartWithBearer() throws ServletException, IOException {
+        // Given
+        when(request.getHeader("Authorization")).thenReturn("Token xyz");
+
+        // When
+        jwtTokenFilter.doFilterInternal(request, response, filterChain);
+
+        // Then
+        verify(filterChain).doFilter(request, response);
+        verifyNoMoreInteractions(response);
+    }
+
+    @Test
+    @DisplayName("Should send error when JWT token has expired")
+    void shouldSendErrorWhenTokenIsExpired() throws ServletException, IOException {
+        // Given
+        when(request.getHeader("Authorization")).thenReturn("Bearer expired-token");
+        lenient().when(response.getWriter()).thenReturn(printWriter);
+
+        ExpiredJwtException exception = mock(ExpiredJwtException.class);
+        try (var jwtsStaticMock = mockStatic(Jwts.class)) {
+            jwtsStaticMock.when(Jwts::parser).thenThrow(exception);
+
+            // When
+            jwtTokenFilter.doFilterInternal(request, response, filterChain);
+
+            // Then
+            verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid JWT token");
+            verify(filterChain, never()).doFilter(request, response);
+        }
+    }
+
+    @Test
+    @DisplayName("Should send error when JWT token is malformed")
+    void shouldSendErrorWhenTokenIsMalformed() throws ServletException, IOException {
+        // Given
+        when(request.getHeader("Authorization")).thenReturn("Bearer malformed-token");
+        lenient().when(response.getWriter()).thenReturn(printWriter);
+
+        MalformedJwtException exception = mock(MalformedJwtException.class);
+        try (var jwtsStaticMock = mockStatic(Jwts.class)) {
+            jwtsStaticMock.when(Jwts::parser).thenThrow(exception);
+
+            // When
+            jwtTokenFilter.doFilterInternal(request, response, filterChain);
+
+            // Then
+            verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid JWT token");
+            verify(filterChain, never()).doFilter(request, response);
+        }
+    }
+
+    @Test
+    @DisplayName("Should send error when JWT token signature is invalid")
+    void shouldSendErrorWhenTokenSignatureIsInvalid() throws ServletException, IOException {
+        // Given
+        when(request.getHeader("Authorization")).thenReturn("Bearer invalid-signature-token");
+        lenient().when(response.getWriter()).thenReturn(printWriter);
+
+        SignatureException exception = mock(SignatureException.class);
+        try (var jwtsStaticMock = mockStatic(Jwts.class)) {
+            jwtsStaticMock.when(Jwts::parser).thenThrow(exception);
+
+            // When
+            jwtTokenFilter.doFilterInternal(request, response, filterChain);
+
+            // Then
+            verify(response).sendError(HttpServletResponse.SC_UNAUTHORIZED, "Invalid JWT token");
+            verify(filterChain, never()).doFilter(request, response);
+        }
+    }
+
+    @Test
+    @DisplayName("Should continue filter chain when JWT token is valid")
+    void shouldContinueFilterChainWhenTokenIsValid() throws ServletException, IOException {
+        // Given
+        when(request.getHeader("Authorization")).thenReturn("Bearer valid-token");
+
+        // Mock for JWT parser and Claims
+        try (var jwtsStaticMock = mockStatic(Jwts.class)) {
+            var parser = mock(io.jsonwebtoken.JwtParser.class);
+            var jws = mock(io.jsonwebtoken.Jws.class);
+            var claims = mock(Claims.class);
+
+            jwtsStaticMock.when(Jwts::parser).thenReturn(parser);
+            when(parser.setSigningKey(anyString())).thenReturn(parser);
+            when(parser.parseClaimsJws(anyString())).thenReturn(jws);
+            when(jws.getBody()).thenReturn(claims);
+
+            // When
+            jwtTokenFilter.doFilterInternal(request, response, filterChain);
+
+            // Then
+            verify(filterChain).doFilter(request, response);
+            verifyNoMoreInteractions(response);
+        }
+    }
+}

--- a/api/src/test/java/com/books/api/security/JwtTokenProviderTest.java
+++ b/api/src/test/java/com/books/api/security/JwtTokenProviderTest.java
@@ -1,0 +1,44 @@
+package com.books.api.security;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+@ExtendWith(MockitoExtension.class)
+public class JwtTokenProviderTest {
+
+    @InjectMocks
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @BeforeEach
+    void setUp() {
+    }
+
+    @Test
+    @DisplayName("Test token creation")
+    void testCreateToken() {
+        String token = jwtTokenProvider.createToken();
+        assertNotNull(token, "Token should not be null");
+    }
+
+    @Test
+    @DisplayName("Test getSecretKey")
+    void testGetSecretKey() {
+        assertNotNull(jwtTokenProvider.getSecretKey(), "SecretKey should not be null");
+    }
+}

--- a/api/src/test/java/com/books/api/security/RateLimitingFilterTest.java
+++ b/api/src/test/java/com/books/api/security/RateLimitingFilterTest.java
@@ -1,0 +1,271 @@
+package com.books.api.security;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+
+import com.books.api.config.RateLimitingConfig;
+import com.books.api.config.RateLimitingConfig.EndpointLimit;
+import com.books.api.service.RateLimitingService;
+import com.books.api.service.RateLimitingService.RateLimitInfo;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+/**
+ * Unit tests for {@link RateLimitingFilter}.
+ * Verifies the filter's behavior with different rate limit configurations.
+ *
+ * @author books
+ */
+@ExtendWith(MockitoExtension.class)
+public class RateLimitingFilterTest {
+
+    @Mock
+    private RateLimitingConfig rateLimitingConfig;
+
+    @Mock
+    private RateLimitingService rateLimitingService;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @Mock
+    private HttpServletResponse response;
+
+    @Mock
+    private FilterChain filterChain;
+
+    @Mock
+    private PrintWriter printWriter;
+
+    @InjectMocks
+    private RateLimitingFilter rateLimitingFilter;
+
+    private EndpointLimit endpointLimit;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        // Basic test configuration
+        endpointLimit = new EndpointLimit();
+        endpointLimit.setLimit(10);
+        endpointLimit.setRefreshPeriod(60);
+        endpointLimit.setTimeUnit(TimeUnit.SECONDS);
+
+        lenient().when(rateLimitingConfig.isEnabled()).thenReturn(true);
+        lenient().when(request.getRemoteAddr()).thenReturn("127.0.0.1");
+        lenient().when(rateLimitingConfig.getStrategy()).thenReturn("IP_ADDRESS");
+        lenient().when(request.getContextPath()).thenReturn("");
+        lenient().when(request.getServletPath()).thenReturn("");
+        lenient().when(response.getWriter()).thenReturn(printWriter);
+    }
+
+    @Test
+    @DisplayName("Should skip rate limiting when disabled")
+    void shouldSkipRateLimitingWhenDisabled() throws ServletException, IOException {
+        // Given
+        when(rateLimitingConfig.isEnabled()).thenReturn(false);
+
+        // When
+        rateLimitingFilter.doFilterInternal(request, response, filterChain);
+
+        // Then
+        verify(filterChain).doFilter(request, response);
+        verifyNoInteractions(rateLimitingService);
+    }
+
+    @Test
+    @DisplayName("Should allow request when within rate limit")
+    void shouldAllowRequestWhenWithinRateLimit() throws ServletException, IOException {
+        // Given
+        String path = "/api/authors";
+        when(request.getRequestURI()).thenReturn(path);
+
+        // Configure the rate limiting service
+        when(rateLimitingService.findEndpointLimit(path)).thenReturn(endpointLimit);
+        when(rateLimitingService.isRequestAllowed(anyString(), eq(endpointLimit))).thenReturn(true);
+
+        // When
+        rateLimitingFilter.doFilterInternal(request, response, filterChain);
+
+        // Then
+        verify(filterChain).doFilter(request, response);
+        verify(response, never()).setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+    }
+
+    @Test
+    @DisplayName("Should reject request when exceeds rate limit")
+    void shouldRejectRequestWhenExceedsRateLimit() throws ServletException, IOException {
+        // Given
+        String path = "/api/authors";
+        when(request.getRequestURI()).thenReturn(path);
+        when(response.getWriter()).thenReturn(printWriter);
+
+        // Configure the rate limiting service
+        when(rateLimitingService.findEndpointLimit(path)).thenReturn(endpointLimit);
+        when(rateLimitingService.isRequestAllowed(anyString(), eq(endpointLimit))).thenReturn(false);
+
+        // When
+        rateLimitingFilter.doFilterInternal(request, response, filterChain);
+
+        // Then
+        verify(response).setStatus(HttpStatus.TOO_MANY_REQUESTS.value());
+        verify(printWriter).write("Rate limit exceeded. Please try again later.");
+        verify(filterChain, never()).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("Should add rate limit headers when configured")
+    void shouldAddRateLimitHeadersWhenConfigured() throws ServletException, IOException {
+        // Given
+        String path = "/api/authors";
+        when(request.getRequestURI()).thenReturn(path);
+
+        // Configure the rate limiting service
+        when(rateLimitingService.findEndpointLimit(path)).thenReturn(endpointLimit);
+        when(rateLimitingService.isRequestAllowed(anyString(), eq(endpointLimit))).thenReturn(true);
+        when(rateLimitingConfig.isResponseHeaders()).thenReturn(true);
+
+        // Mock for rate limit information
+        RateLimitInfo rateLimitInfo = new RateLimitInfo(10, 5, System.currentTimeMillis() + 30000);
+        when(rateLimitingService.getRateLimitInfo(anyString(), eq(endpointLimit))).thenReturn(rateLimitInfo);
+
+        // When
+        rateLimitingFilter.doFilterInternal(request, response, filterChain);
+
+        // Then
+        verify(response).addHeader(eq("X-RateLimit-Limit"), anyString());
+        verify(response).addHeader(eq("X-RateLimit-Remaining"), anyString());
+        verify(response).addHeader(eq("X-RateLimit-Reset"), anyString());
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("Should use IP-based rate limiting strategy by default")
+    void shouldUseIpBasedRateLimitingStrategyByDefault() throws ServletException, IOException {
+        // Given
+        String path = "/api/authors";
+        String ipAddress = "192.168.1.1";
+        when(request.getRequestURI()).thenReturn(path);
+        when(request.getRemoteAddr()).thenReturn(ipAddress);
+
+        // Configure the rate limiting service
+        when(rateLimitingService.findEndpointLimit(path)).thenReturn(endpointLimit);
+        when(rateLimitingConfig.getStrategy()).thenReturn("IP_ADDRESS");
+
+        // Capture the rate limit key
+        when(rateLimitingService.isRequestAllowed(anyString(), eq(endpointLimit))).thenReturn(true);
+
+        // When
+        rateLimitingFilter.doFilterInternal(request, response, filterChain);
+
+        // Then
+        verify(rateLimitingService).isRequestAllowed(eq(ipAddress + ":" + path), eq(endpointLimit));
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("Should generate correct key for USER strategy")
+    void shouldGenerateCorrectKeyForUserStrategy() throws ServletException, IOException {
+        // Given
+        String path = "/api/authors";
+        when(request.getRequestURI()).thenReturn(path);
+        when(rateLimitingConfig.getStrategy()).thenReturn("USER");
+
+        // Configure the rate limiting service
+        when(rateLimitingService.findEndpointLimit(path)).thenReturn(endpointLimit);
+        when(rateLimitingService.isRequestAllowed(eq("user:" + path), eq(endpointLimit))).thenReturn(true);
+
+        // When
+        rateLimitingFilter.doFilterInternal(request, response, filterChain);
+
+        // Then
+        verify(rateLimitingService).isRequestAllowed(eq("user:" + path), eq(endpointLimit));
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("Should generate correct key for TOKEN strategy with Authorization header")
+    void shouldGenerateCorrectKeyForTokenStrategyWithAuth() throws ServletException, IOException {
+        // Given
+        String path = "/api/authors";
+        String token = "Bearer abc123";
+        when(request.getRequestURI()).thenReturn(path);
+        when(rateLimitingConfig.getStrategy()).thenReturn("TOKEN");
+        when(request.getHeader("Authorization")).thenReturn(token);
+
+        // Configure the rate limiting service
+        when(rateLimitingService.findEndpointLimit(path)).thenReturn(endpointLimit);
+        when(rateLimitingService.isRequestAllowed(eq(token + ":" + path), eq(endpointLimit))).thenReturn(true);
+
+        // When
+        rateLimitingFilter.doFilterInternal(request, response, filterChain);
+
+        // Then
+        verify(rateLimitingService).isRequestAllowed(eq(token + ":" + path), eq(endpointLimit));
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("Should generate correct key for TOKEN strategy without Authorization header")
+    void shouldGenerateCorrectKeyForTokenStrategyWithoutAuth() throws ServletException, IOException {
+        // Given
+        String path = "/api/authors";
+        when(request.getRequestURI()).thenReturn(path);
+        when(rateLimitingConfig.getStrategy()).thenReturn("TOKEN");
+        when(request.getHeader("Authorization")).thenReturn(null);
+
+        // Configure the rate limiting service
+        when(rateLimitingService.findEndpointLimit(path)).thenReturn(endpointLimit);
+        when(rateLimitingService.isRequestAllowed(eq("anonymous:" + path), eq(endpointLimit))).thenReturn(true);
+
+        // When
+        rateLimitingFilter.doFilterInternal(request, response, filterChain);
+
+        // Then
+        verify(rateLimitingService).isRequestAllowed(eq("anonymous:" + path), eq(endpointLimit));
+        verify(filterChain).doFilter(request, response);
+    }
+
+    @Test
+    @DisplayName("Should use IP-based rate limiting for unrecognized strategy")
+    void shouldUseIpBasedRateLimitingForUnrecognizedStrategy() throws ServletException, IOException {
+        // Given
+        String path = "/api/authors";
+        String ipAddress = "192.168.1.1";
+        when(request.getRequestURI()).thenReturn(path);
+        when(request.getRemoteAddr()).thenReturn(ipAddress);
+        when(rateLimitingConfig.getStrategy()).thenReturn("UNKNOWN_STRATEGY");
+
+        // Configure the rate limiting service
+        when(rateLimitingService.findEndpointLimit(path)).thenReturn(endpointLimit);
+        when(rateLimitingService.isRequestAllowed(eq(ipAddress + ":" + path), eq(endpointLimit))).thenReturn(true);
+
+        // When
+        rateLimitingFilter.doFilterInternal(request, response, filterChain);
+
+        // Then
+        verify(rateLimitingService).isRequestAllowed(eq(ipAddress + ":" + path), eq(endpointLimit));
+        verify(filterChain).doFilter(request, response);
+    }
+
+}

--- a/api/src/test/java/com/books/api/service/RateLimitingServiceTest.java
+++ b/api/src/test/java/com/books/api/service/RateLimitingServiceTest.java
@@ -1,0 +1,85 @@
+package com.books.api.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.concurrent.TimeUnit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.books.api.config.RateLimitingConfig;
+import com.books.api.config.RateLimitingConfig.EndpointLimit;
+
+@ExtendWith(MockitoExtension.class)
+public class RateLimitingServiceTest {
+
+    @Mock
+    private RateLimitingConfig rateLimitingConfig;
+
+    @InjectMocks
+    private RateLimitingService rateLimitingService;
+
+    @BeforeEach
+    void setUp() {
+        RateLimitingConfig.RateLimitSettings defaultSettings = mock(RateLimitingConfig.RateLimitSettings.class);
+        lenient().when(defaultSettings.getLimit()).thenReturn(100);
+        lenient().when(rateLimitingConfig.getDefaultSettings()).thenReturn(defaultSettings);
+    }
+
+    @Test
+    @DisplayName("Test isRequestAllowed method")
+    void testIsRequestAllowed() {
+        EndpointLimit endpointLimit = mock(EndpointLimit.class);
+        lenient().when(endpointLimit.getLimit()).thenReturn(100);
+        lenient().when(endpointLimit.getRefreshPeriod()).thenReturn(60);
+        lenient().when(endpointLimit.getTimeUnit()).thenReturn(TimeUnit.SECONDS);
+
+        boolean result = rateLimitingService.isRequestAllowed("testKey", endpointLimit);
+
+        assertTrue(result);
+    }
+
+    @Test
+    @DisplayName("Test findEndpointLimit method")
+    void testFindEndpointLimit() {
+        EndpointLimit endpointLimit = rateLimitingService.findEndpointLimit("/test/path");
+
+        assertNotNull(endpointLimit);
+    }
+
+    @Test
+    @DisplayName("Test getRateLimitInfo method")
+    void testGetRateLimitInfo() {
+        EndpointLimit endpointLimit = mock(EndpointLimit.class);
+        when(endpointLimit.getLimit()).thenReturn(100);
+
+        RateLimitingService.RateLimitInfo info = rateLimitingService.getRateLimitInfo("testKey", endpointLimit);
+
+        assertEquals(100, info.limit());
+    }
+
+    @Test
+    void testIsRequestAllowedWhenRateLimitingDisabled() {
+        // Arrange
+        when(rateLimitingConfig.isEnabled()).thenReturn(true);
+        String key = "anyKey";
+        EndpointLimit endpointLimit = new EndpointLimit();
+
+        // Act
+        boolean result = rateLimitingService.isRequestAllowed(key, endpointLimit);
+
+        // Assert
+        assertTrue(result);
+    }
+
+}

--- a/api/src/test/resources/application-test.yml
+++ b/api/src/test/resources/application-test.yml
@@ -1,0 +1,24 @@
+# Test configuration
+CONTEXT_PATH: /api
+
+# Database configuration for tests
+spring:
+  datasource:
+    url: jdbc:oracle:thin:@localhost:1521:XE
+    username: sa
+    password: sa
+    driver-class-name: oracle.jdbc.OracleDriver
+  
+  # JPA configuration for tests
+  jpa:
+    hibernate:
+      ddl-auto: validate
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.OracleDialect
+    show-sql: true
+
+# Security configuration for tests
+security:
+  secret-key: test-secret-key
+  expiration: 3600000

--- a/test-dashboard.html
+++ b/test-dashboard.html
@@ -148,7 +148,7 @@
     </div> 
     <footer> 
         <div class="container"> 
-            Books & Authors API - Coverage Dashboard - Updated: 18/05/2025 17:10 
+            Books & Authors API - Coverage Dashboard - Updated: 19/05/2025 01:04 
         </div> 
     </footer> 
 </body> 


### PR DESCRIPTION
Introduce rate limiting for API endpoints to prevent abuse and ensure fair usage. Includes configuration, service, filter, and comprehensive unit tests. Rate limiting can be configured per endpoint with different strategies (IP, user, token). Added rate limit headers in responses for better client awareness.