### PR TITLE
docs: add Apache License 2.0 and update README with license badge

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,23 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+Copyright 2024 Authors of Books and Authors API
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+-------------------------------------------------------------------------------
+
+This repository contains a basic Java Spring Boot project structure with PL/SQL integration for educational and open-source purposes. The source code and API may be freely used, modified, and distributed under the terms of the Apache 2.0 License. No warranty or liability is provided by the authors. This project is intended as a starting point for building RESTful APIs with Java, Spring Boot, and Oracle PL/SQL.

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ A RESTful API for managing books and authors with a Java, Spring Boot, and PL/SQ
   <a href="https://h2database.com/" target="_blank"><img src="https://img.shields.io/badge/H2-Database-4DB33F?style=flat&logo=java&logoColor=white" alt="H2 Database"></a>
   <a href="https://www.slf4j.org/" target="_blank"><img src="https://img.shields.io/badge/SLF4J-2.x-FF9900?style=flat&logo=java&logoColor=white" alt="SLF4J"></a>
   <a href="https://logback.qos.ch/" target="_blank"><img src="https://img.shields.io/badge/Logback-1.4.x-003366?style=flat&logo=java&logoColor=white" alt="Logback"></a>
+  <a href="https://www.apache.org/licenses/LICENSE-2.0" target="_blank"><img src="https://img.shields.io/badge/License-Apache_2.0-blue.svg" alt="License: Apache 2.0"></a>
 </p>
 
 ## Project Architecture
@@ -248,4 +249,8 @@ _Built by_
 
 - **Yovany Suárez Silva** - _Full Stack Software Engineer_ - [desobsesor](https://github.com/desobsesor)
 - Website - [https://desobsesor.github.io/portfolio-web](https://desobsesor.github.io/portfolio-web/)
+
+## License
+
+This project is licensed under the [Apache License 2.0](LICENSE). You are free to use, modify, and distribute this software under the terms of the Apache License, Version 2.0.
 


### PR DESCRIPTION
This commit introduces the Apache License 2.0 to the project, ensuring proper licensing for open-source use. Additionally, the README file has been updated to include a license badge and a dedicated section for the license details, providing clarity to users and contributors about the project's licensing terms.